### PR TITLE
Card image on Trade View is no longer clickable.

### DIFF
--- a/app/views/trades/index.html.erb
+++ b/app/views/trades/index.html.erb
@@ -51,7 +51,7 @@
         <input class="toggle-wishlist" wish-list-id="${search('id', card.attributes.id, wishlist) === undefined ? -1 : search('id', card.attributes.id, wishlist).id}" data-id="${card.attributes.id}" id="wl-checkbox-for-${card.attributes.id}" type="checkbox" ${search('id', card.attributes.id, wishlist) === undefined ? '' : 'checked' }>
         <label for="wl-checkbox-for-${card.attributes.id}"></label>
       </div>
-      <a class="card-grid-item" href="/cards/${card.attributes.id}">
+      <a class="card-grid-item">
         <img class="card" alt="${card.attributes.name}" title="${card.attributes.name}" src="${card.attributes.image_url}">
       </a>
      <div class="trade-proposal-request">


### PR DESCRIPTION
Clicking on the card would take you to a generic card profile page, that we have not implemented yet.  This fixes that. 