### PR TITLE
Received Trades -  first draft functionality

### DIFF
--- a/app/controllers/received_trades_controller.rb
+++ b/app/controllers/received_trades_controller.rb
@@ -3,8 +3,7 @@ class ReceivedTradesController < ApplicationController
   def create
     trade = @user.received_trades.find_or_initialize_by(rarity: params[:rarity])
     fallback_value = trade.num_received ? trade.num_received : 0
-    trade.num_received = params[:num_received]
-    if trade.save
+    if trade.update(num_received: params[:num_received])
       render json: { success: 'true' }, status: 200
     else
       render json: { success: 'false', fallback_value: fallback_value }, status: 200

--- a/app/controllers/received_trades_controller.rb
+++ b/app/controllers/received_trades_controller.rb
@@ -1,0 +1,18 @@
+class ReceivedTradesController < ApplicationController
+  before_action :set_user, only: [:create]
+  def create
+    trade = @user.received_trades.find_or_initialize_by(rarity: params[:rarity])
+    fallback_value = trade.num_received ? trade.num_received : 0
+    trade.num_received = params[:num_received]
+    if trade.save
+      render json: { success: 'true' }, status: 200
+    else
+      render json: { success: 'false', fallback_value: fallback_value }, status: 200
+    end
+  end
+
+  private
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+end

--- a/app/models/received_trade.rb
+++ b/app/models/received_trade.rb
@@ -1,0 +1,15 @@
+class ReceivedTrade < ApplicationRecord
+  NUM_ALLOWED_BY_RARITY = {
+    'rare' => 1,
+    'uncommon' => 3,
+    'common' => 11,
+  }
+
+  belongs_to :user
+
+  validates :rarity, inclusion: { in: NUM_ALLOWED_BY_RARITY.keys, message: "%{value} is not a valid rarity" }
+  validates_each :num_received do |record, attr, value|
+    record.errors.add(attr, 'too many!') if value > ReceivedTrade::NUM_ALLOWED_BY_RARITY[record.rarity]
+    record.errors.add(attr, 'too few!') if value < 0
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   has_many :cards, through: :ownerships
   has_many :tradables
   has_many :tradable_cards, through: :tradables, source: :card
+  has_many :received_trades
   has_many :wishes
   has_many :wishlist_items, through: :wishes, source: :card
   has_many :wins, class_name: 'Match', foreign_key: 'winner_id'
@@ -25,6 +26,17 @@ class User < ApplicationRecord
 
   def wishlist
     wishlist_items
+  end
+
+  def trades_received_and_allowed_by_rarity
+    trades = [];
+    ReceivedTrade::NUM_ALLOWED_BY_RARITY.keys.each do |rarity|
+      num_allowed = ReceivedTrade::NUM_ALLOWED_BY_RARITY[rarity]
+      received = received_trades.where(rarity: rarity).first
+      num_received = received ? received.num_received : 0
+      trades << {:rarity => rarity, :num_received => num_received, :num_allowed => num_allowed}
+    end
+    trades
   end
 
   def to_s

--- a/app/views/dashboard/_user_trades.html.erb
+++ b/app/views/dashboard/_user_trades.html.erb
@@ -7,19 +7,41 @@
     <div class="alternating table two-col">
       <div class="headings row">
         <p>Trades</p>
-        <p>Remaining</p>
+        <p>Total Received</p>
+        <p>Total Allowed</p>
       </div>
-      <div class="row">
-        <p>Rare:</p>
-        <input type="number" value="1" name="rare" label="Rare">
-      </div>
-      <div class="row">
-       <p>Uncommon</p><input type="number" value="3" name="uncommon" label="Uncommon">
-      </div>
-      <div class="row">
-        <p>Common:</p>
-        <input type="number" value="11" name="rare" label="Common">
+      <% @user.trades_received_and_allowed_by_rarity.each do |trade| %>
+        <div class="row">
+          <p><%= trade[:rarity].capitalize %></p>
+          <input type="number" value="<%= trade[:num_received] %>" name="rarity-<%= trade[:rarity] %>" label="<%= trade[:rarity].capitalize %>" data-rarity="<%= trade[:rarity] %>" min="0" max="<%= trade[:num_allowed] %>"/>
+          <p><%= trade[:num_allowed] %></p>
         </div>
-      </div>
+      <% end %>
+    </div>
   </div>
 </div>
+
+<script>
+  $(function() {
+    if (<%= @user.id %> != <%= current_user.id %>) $('input[name^="rarity"]').prop('disabled', 'disabled');
+
+    $(document).off('change', 'input[name^="rarity"]');
+    $(document).on('change', 'input[name^="rarity"]', function() {
+      let $this = $(this);
+      let rarity = $this.attr('data-rarity');
+      let num_received = $this.val();
+      xhrRequest('/received_trades/', "POST",
+        function(response) {
+          if (response.success == 'false') {
+            $this.val(response.fallback_value);
+          }
+        },
+        {
+          user_id: <%= current_user.id %>,
+          rarity: rarity,
+          num_received: num_received
+        }
+      );
+    });
+  });
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
   resources :ownerships, only: [:create, :destroy]
   resources :wishlists, only: [:index, :show, :update]
   resources :tradables, only: [:index, :show, :create, :destroy]
+  resources :received_trades, only: [:create]
 end

--- a/db/migrate/20181103182705_create_received_trades.rb
+++ b/db/migrate/20181103182705_create_received_trades.rb
@@ -1,0 +1,11 @@
+class CreateReceivedTrades < ActiveRecord::Migration[5.2]
+  def change
+    create_table :received_trades do |t|
+      t.belongs_to :user, foreign_key: true
+      t.string :rarity
+      t.integer :num_received
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_19_174302) do
+ActiveRecord::Schema.define(version: 2018_11_03_182705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,15 @@ ActiveRecord::Schema.define(version: 2018_10_19_174302) do
     t.datetime "updated_at", null: false
     t.index ["card_id"], name: "index_ownerships_on_card_id"
     t.index ["collection_id"], name: "index_ownerships_on_collection_id"
+  end
+
+  create_table "received_trades", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "rarity"
+    t.integer "num_received"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_received_trades_on_user_id"
   end
 
   create_table "tradables", force: :cascade do |t|
@@ -84,4 +93,5 @@ ActiveRecord::Schema.define(version: 2018_10_19_174302) do
     t.index ["user_id"], name: "index_wishes_on_user_id"
   end
 
+  add_foreign_key "received_trades", "users"
 end


### PR DESCRIPTION
First draft functionality of tracking number of cards received in trade.

In the user dashboard, the request is sent when the input generates a change event.  I've been triggering this by pressing enter after inputting a new value or using the up and down buttons provided by the browser for input number type.

One shouldn't be able to change the values of other users' dashboards, and this is currently only prevented in the front end by disabling the input.  No server side authorization is done for that, but should be done as a follow up to do item.