### PR TITLE
Trades allowed dec 2019

### DIFF
--- a/app/models/received_trade.rb
+++ b/app/models/received_trade.rb
@@ -19,7 +19,7 @@ class ReceivedTrade < ApplicationRecord
   private
 
   def self.num_trade_sets
-    2
+    Setting.first.trade_allowance_period # Only one setting currently.  Will need to update to get the correct settings if we implement multiple leagues
   end
 
   def self.extra_trade_sets(user_name)

--- a/app/models/received_trade.rb
+++ b/app/models/received_trade.rb
@@ -8,12 +8,12 @@ class ReceivedTrade < ApplicationRecord
 
   validates :rarity, inclusion: { in: NUM_PER_PACK_BY_RARITY.keys, message: "%{value} is not a valid rarity" }
   validates_each :num_received do |record, attr, value|
-    record.errors.add(attr, 'too many!') if value > num_allowed(record.rarity, record.user.name)
+    record.errors.add(attr, 'too many!') if value > num_allowed(record.rarity, record.user.id)
     record.errors.add(attr, 'too few!') if value < 0
   end
 
-  def self.num_allowed(rarity, user_name)
-    NUM_PER_PACK_BY_RARITY[rarity] * (num_trade_sets + extra_trade_sets(user_name))
+  def self.num_allowed(rarity, user_id)
+    NUM_PER_PACK_BY_RARITY[rarity] * (num_trade_sets + extra_trade_sets(user_id))
   end
 
   private
@@ -22,12 +22,7 @@ class ReceivedTrade < ApplicationRecord
     Setting.first.trade_allowance_period # Only one setting currently.  Will need to update to get the correct settings if we implement multiple leagues
   end
 
-  def self.extra_trade_sets(user_name)
-    case user_name.downcase
-    when 'ben silver', 'mike stempler'
-      1
-    else
-      0
-    end
+  def self.extra_trade_sets(user_id)
+    Setting.first.bonus_trade_users.count(user_id) # Only one setting currently.  Will need to update to get the correct settings if we implement multiple leagues
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ApplicationRecord
   def trades_received_and_allowed_by_rarity
     trades = [];
     ReceivedTrade::NUM_PER_PACK_BY_RARITY.keys.each do |rarity|
-      num_allowed = ReceivedTrade.num_allowed(rarity, name)
+      num_allowed = ReceivedTrade.num_allowed(rarity, id)
       received = received_trades.where(rarity: rarity).first
       num_received = received ? received.num_received : 0
       trades << {:rarity => rarity, :num_received => num_received, :num_allowed => num_allowed}


### PR DESCRIPTION
This is the first step to remove hard coding for determining the amount of trade sets a user has.  Will use the Settings table's values for trade_allowance_period and bonus_trade_users when calculating the total amount of trade sets.