### PR TITLE
Initial unified profile page card interface

### DIFF
--- a/app/assets/javascripts/app_layout.js
+++ b/app/assets/javascripts/app_layout.js
@@ -35,7 +35,6 @@ var AppLayout = (function() {
 
   let handleWindowClick = function(event) {
     if (!event.target.matches('.drop-down-toggle')) {
-      console.log('handler filed');
       var dropdowns = document.querySelectorAll(".dropdown-content");
       var i;
       for (i = 0; i < dropdowns.length; i++) {
@@ -48,13 +47,6 @@ var AppLayout = (function() {
   }  
 
   // Exposed functions start here
-  let closeOtherDropDown = function() {
-    var dropDownMenus = document.getElementById("top-nav").querySelectorAll(".dropdown-content");           
-    for (var i = 0; i < dropDownMenus.length; i++) {
-      dropDownMenus[i].classList.remove("active");
-    }
-  } 
-
 
   let initialize = function(user_signed_in = false, current_user_id = null) {
     $('.nav_match-logger-btn').on('click', logMatchOnClick);
@@ -80,7 +72,6 @@ var AppLayout = (function() {
 
   return {
     initialize: initialize,
-    closeOtherDropDown: closeOtherDropDown,
     timedAlertClose: timedAlertClose,
   }
 

--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -1,9 +1,19 @@
-var Helpers = (function() {
+var Helpers = (function () {
 
-  let toggleElementById = function(elementId) {
-    console.log('toggle fired');
+  let toggleElementById = (elementId, siblingsToClose) => {
+    if (siblingsToClose) {
+      console.log('sib to close yes')
+      unToggleSiblingElements(siblingsToClose);
+    }
     let target = document.getElementById(elementId);
     target.classList.toggle("active");
+  }
+
+  let unToggleSiblingElements = (target) => {
+    var siblingClass = document.querySelectorAll("." + target);
+    for (var i = 0; i < siblingClass.length; i++) {
+      siblingClass[i].classList.remove('active');
+    }
   }
 
   return {

--- a/app/assets/javascripts/helpers.js
+++ b/app/assets/javascripts/helpers.js
@@ -2,7 +2,6 @@ var Helpers = (function () {
 
   let toggleElementById = (elementId, siblingsToClose) => {
     if (siblingsToClose) {
-      console.log('sib to close yes')
       unToggleSiblingElements(siblingsToClose);
     }
     let target = document.getElementById(elementId);

--- a/app/assets/stylesheets/card-grid/card-grid.scss
+++ b/app/assets/stylesheets/card-grid/card-grid.scss
@@ -28,6 +28,7 @@
                     line-height: calc(#{$box-size}*.8);
                     font-size: calc(#{$box-size}*.8);
                     border-radius: $box-size;
+                    padding:2px;
                     cursor: pointer;
                     opacity: .4;
                     content: "\2665";
@@ -37,6 +38,9 @@
                     color: transparent;  
                     text-shadow: 0 0 0 $color-light;
                     background-color: $color-highlight-mid-import;
+                    @media only screen and (max-width: 500px) {
+                        top: 0;
+                    }
                 }
             }
 

--- a/app/assets/stylesheets/card-grid/card-grid.scss
+++ b/app/assets/stylesheets/card-grid/card-grid.scss
@@ -25,7 +25,7 @@
                 &:before {
                     width:$box-size;
                     height:$box-size;
-                    line-height: $box-size;
+                    line-height: calc(#{$box-size}*.8);
                     font-size: calc(#{$box-size}*.8);
                     border-radius: $box-size;
                     cursor: pointer;

--- a/app/assets/stylesheets/card-grid/card-grid.scss
+++ b/app/assets/stylesheets/card-grid/card-grid.scss
@@ -6,137 +6,147 @@
     &_card-wrapper {
         width: 100%;
         margin: 30px auto;
-        position: relative;
+        display:flex;
+        flex-direction: column;
+        align-items: center;
     }
 
     &_wishlist-toggle {
-        width: 36px;
-        height: 36px;
         top: -25px;
-        right: -10px;
+        right: 20px;
         opacity: 1;
         position: absolute;
         z-index: 2;
+        
 
-        label {
-            position: relative;
-
-            &:before {
-                cursor: pointer;
-                opacity: .4;
-                content: "\2665";
-                position: absolute;
-                color: white;
-                font-size: 35px;
-                background-color: $color-highlight-mid-import;
-                padding: 6px;
-                border-radius: 25px;
-                line-height: 24px;
-                -webkit-tap-highlight-color: transparent;
-                transition: .25s;
-            }
-
-        }
-
-        &_checkbox:checked+label::before {
-            opacity: 1;
-        }
-
-    }
-
-    &_card {
-        width: 100%;
-        text-align: center;
-
-        img {
-            width: 90%;
-            margin: 0;
-        }
-    }
-
-    &_counter {
-        display: flex;
-        margin: 0 auto;
-        justify-content: space-between;
-        align-items: center;
-        text-align: center;
-        width: 90%;
-        background-color: $color-highlight-import;
-        border-radius: 5px;
-
-        [class*="-btn"] {
-            font-weight: bolder;
-            display: flex;
-            justify-content: center;
-        }
-
-        input[type=number]{
-            &:not(.browser-default) {
-                cursor: default;
-                text-align: center;
-                color: $color-light;
-                border-bottom: none;
-                height: 34px;
-                margin-bottom: 0;
-                //Dealing with the wheel space;
-                margin-right: -10px;
-                -moz-appearance: textfield;
-            }
-
-            &:-webkit-inner-spin-button,
-            &:-webkit-outer-spin-button,
-            &:-webkit-inner-adjust-hue-button,
-            &:-webkit-outer-adjust-hue-button {
-                -webkit-appearance: none;
-                margin: 0;
-            }
-
-        }
-
-    }
-
-    &_trade-proposal {
-        width: 90%;
-        margin: 0 auto;
-        text-align: center;
-
-        &-btn {
-            width: 100%;
-
-            span {
-                display: none;
-            }
-
-            &:after {
-                content: "Propose Trade";
-                font-size: 12px;
-            }
-
-            &.not-in-league {
-                background: $color-dark;
-                cursor: default;
-
-                &:after {
-                    content: "Not in League";
+        input[type=checkbox] {
+            $box-size:35px;
+            + label {
+                &:before {
+                    width:$box-size;
+                    height:$box-size;
+                    line-height: $box-size;
+                    font-size: $box-size;
+                    border-radius: $box-size;
+                    cursor: pointer;
+                    opacity: .4;
+                    content: "\2665";
+                    position: absolute;
+                    color: white;
+                    background-color: $color-highlight-mid-import;
                 }
             }
 
+                &:checked+label::before {
+                    opacity: 1;
+                }
+                
+                &:checked+label::after {
+                    content: "";
+                    
+                }
+
+
+            }
+
+
+
+        }
+
+        &_card {
+            width: 90%;
+            text-align: center;
+            position: relative;
+
+            img {
+                width: 100%;
+                margin: 0;
+            }
+        }
+
+        &_counter {
+            display: flex;
+            margin: 0 auto;
+            justify-content: space-between;
+            align-items: center;
+            text-align: center;
+            width: 100%;
+            background-color: $color-highlight-import;
+            border-radius: 5px;
+
+            [class*="-btn"] {
+                font-weight: bolder;
+                display: flex;
+                justify-content: center;
+            }
+
+            input[type=number] {
+                &:not(.browser-default) {
+                    cursor: default;
+                    text-align: center;
+                    color: $color-light;
+                    border-bottom: none;
+                    height: 34px;
+                    margin-bottom: 0;
+                    //Dealing with the wheel space;
+                    margin-right: -10px;
+                    -moz-appearance: textfield;
+                }
+
+                &:-webkit-inner-spin-button,
+                &:-webkit-outer-spin-button,
+                &:-webkit-inner-adjust-hue-button,
+                &:-webkit-outer-adjust-hue-button {
+                    -webkit-appearance: none;
+                    margin: 0;
+                }
+
+            }
+
+        }
+
+        &_trade-proposal {
+            width: 90%;
+            margin: 0 auto;
+            text-align: center;
+
+            &-btn {
+                width: 100%;
+
+                span {
+                    display: none;
+                }
+
+                &:after {
+                    content: "Propose Trade";
+                    font-size: 12px;
+                }
+
+                &.not-in-league {
+                    background: $color-dark;
+                    cursor: default;
+
+                    &:after {
+                        content: "Not in League";
+                    }
+                }
+
+            }
+        }
+
+        @media only screen and (max-width: 800px) {
+            grid-template-columns: repeat(3, 33.3%);
+        }
+
+        @media only screen and (max-width: 650px) {
+            grid-template-columns: repeat(2, 50%);
+        }
+
+        @media only screen and (max-width: 400px) {
+            display: block;
+
+            &_card-wrapper {
+                margin-bottom: 25px;
+            }
         }
     }
-    
-    @media only screen and (max-width: 800px) {
-        grid-template-columns: repeat(3, 33.3%);
-    }
-
-    @media only screen and (max-width: 650px) {
-        grid-template-columns: repeat(2, 50%);
-    }
-
-    @media only screen and (max-width: 400px) {
-        display: block;
-
-        &_card-wrapper {
-            margin-bottom: 25px;
-        }
-    }
-}

--- a/app/assets/stylesheets/card-grid/card-grid.scss
+++ b/app/assets/stylesheets/card-grid/card-grid.scss
@@ -20,18 +20,19 @@
         
 
         input[type=checkbox] {
-            $box-size:35px;
             + label {
                 &:before {
-                    width:$box-size;
-                    height:$box-size;
-                    line-height: calc(#{$box-size}*.8);
-                    font-size: calc(#{$box-size}*.8);
-                    border-radius: $box-size;
+                    $checkbox-size:35px;
+                    font-family: "Font Awesome 5 Free";
+                    font-weight:400;
+                    content: "\f004";
+                    width: $checkbox-size;
+                    height: $checkbox-size;
+                    font-size: calc(#{$checkbox-size}*.7);
+                    border-radius:  $checkbox-size;
                     padding:2px;
                     cursor: pointer;
                     opacity: .4;
-                    content: "\2665";
                     position: absolute;
                     color: $color-light;
                     //fix for mobile color issues;

--- a/app/assets/stylesheets/card-grid/card-grid.scss
+++ b/app/assets/stylesheets/card-grid/card-grid.scss
@@ -26,13 +26,16 @@
                     width:$box-size;
                     height:$box-size;
                     line-height: $box-size;
-                    font-size: $box-size;
+                    font-size: calc(#{$box-size}*.8);
                     border-radius: $box-size;
                     cursor: pointer;
                     opacity: .4;
                     content: "\2665";
                     position: absolute;
-                    color: white;
+                    color: $color-light;
+                    //fix for mobile color issues;
+                    color: transparent;  
+                    text-shadow: 0 0 0 $color-light;
                     background-color: $color-highlight-mid-import;
                 }
             }
@@ -142,7 +145,7 @@
             grid-template-columns: repeat(2, 50%);
         }
 
-        @media only screen and (max-width: 400px) {
+        @media only screen and (max-width: 500px) {
             display: block;
 
             &_card-wrapper {

--- a/app/assets/stylesheets/dashboard/dashboard.scss
+++ b/app/assets/stylesheets/dashboard/dashboard.scss
@@ -105,6 +105,12 @@
         }
     }
 
+    &_card-view {
+        display:none;
+        &.active {
+            display:block;
+        }
+    }
     &_collection {
         margin-top: $section-margin;
 

--- a/app/assets/stylesheets/dashboard/dashboard.scss
+++ b/app/assets/stylesheets/dashboard/dashboard.scss
@@ -183,7 +183,8 @@
     .dashboard_card-view-cell {
         .dashboard_wishlist-toggle {
             &:checked+label:after {
-                content: '\00d7';
+                font-size: calc(#{$checkbox-size}*.7);
+                content: '\f00d';
             }
         }
     }

--- a/app/assets/stylesheets/dashboard/dashboard.scss
+++ b/app/assets/stylesheets/dashboard/dashboard.scss
@@ -157,12 +157,11 @@
 
     &_card-view {
         display: none;
-       
+
         &-cell {
-            &:last-of-type {
-                flex: 0 0 100px;
-                text-align: center;
-            }
+            justify-self: flex-end;
+            flex: 0 0 100px;
+            text-align: center;
 
             &:first-of-type {
                 text-align: left;
@@ -170,6 +169,7 @@
                 overflow: hidden;
                 text-overflow: ellipsis;
                 flex-wrap: nowrap;
+                justify-self: flex-start;
             }
         }
 
@@ -182,10 +182,9 @@
 #wishlist {
     .dashboard_card-view-cell {
         .dashboard_wishlist-toggle {
-            &:checked + label:after {
+            &:checked+label:after {
                 content: '\00d7';
-              }
-            
+            }
         }
     }
 }

--- a/app/assets/stylesheets/dashboard/dashboard.scss
+++ b/app/assets/stylesheets/dashboard/dashboard.scss
@@ -105,7 +105,7 @@
         }
     }
 
-    &_card-interface{
+    &_card-interface {
         background: $color-nuetral;
 
         &-wrapper {
@@ -113,26 +113,30 @@
         }
 
         &_tab-wrapper {
-            display:flex;
-            background:$color-light;
+            display: flex;
+            background: $color-light;
         }
 
         &_tab-btn {
             background: rgba($color-dark, .65);
-            margin-right:5px;
-            width:150px;
+            margin-right: 5px;
+            width: 150px;
             border: 2px solid $color-dark;
-            border-bottom: 1px solid rgba($color-dark, .15);;
+            border-bottom: 1px solid rgba($color-dark, .15);
+            ;
             border-bottom-left-radius: 0;
             border-bottom-right-radius: 0;
+
             &:hover {
                 background: rgba($color-dark, .8);
             }
+
             &.active {
-               background: $color-dark;  
-              &:hover {
-                background: $color-dark;  
-              }
+                background: $color-dark;
+
+                &:hover {
+                    background: $color-dark;
+                }
             }
         }
 
@@ -140,45 +144,25 @@
             display: flex;
             justify-content: flex-end;
             align-items: center;
-            background-color: $color-dark;     
+            background-color: $color-dark;
         }
+
         &_action-btn {
             padding: 0 10px;
             font-size: 12px;
-            margin:5px;
+            margin: 5px;
         }
-        
-        &_cell {
-                &:first-of-type {
-                    text-align: left;
-                    flex: 1 1 auto;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    flex-wrap: nowrap;
-                }
-                &:last-of-type {
-                    flex: 0 0 100px;
-                }
-                
-            }
 
-        
     }
 
     &_card-view {
-        display:none;
-        &.active {
-            display:block;
-        }
-    }
-
-
-
-    &_collection {
+        display: none;
        
-        &_cell {
-            flex: 0 0 100px;
-            text-align: center;
+        &-cell {
+            &:last-of-type {
+                flex: 0 0 100px;
+                text-align: center;
+            }
 
             &:first-of-type {
                 text-align: left;
@@ -187,55 +171,21 @@
                 text-overflow: ellipsis;
                 flex-wrap: nowrap;
             }
-            &:last-of-type {
-                flex: 0 0 100px;
-            }
-
         }
 
-        &_for-trade-toggle {
-            position: relative;
-            display: inline;
-
-            &:before {
-                background: $color-nuetral;
-                content: "No way!";
-
-                cursor: pointer;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                position: absolute;
-                color: $color-light;
-
-                padding: 5px;
-                -webkit-tap-highlight-color: transparent;
-                transition: .25s;
-                height: 36px;
-                width: 85px;
-                font-size: 10px;
-                top: -18px;
-                text-transform: uppercase;
-                letter-spacing: .5px;
-            }
-
-            &_checkbox:checked+label::before {
-                content: "For Trade";
-                background-color: $color-highlight-import;
-            }
+        &.active {
+            display: block;
         }
     }
+}
 
-    &_wishlist {
-        &-cell {
-            &:last-of-type {
-                flex: 0 0 100px;
-            }
-
-            .dashboard_wishlist_remove-btn {
-                width: 85px;
-                font-size: 10px;
-            }
+#wishlist {
+    .dashboard_card-view-cell {
+        .dashboard_wishlist-toggle {
+            &:checked + label:after {
+                content: '\00d7';
+              }
+            
         }
     }
 }

--- a/app/assets/stylesheets/dashboard/dashboard.scss
+++ b/app/assets/stylesheets/dashboard/dashboard.scss
@@ -105,35 +105,80 @@
         }
     }
 
+    &_card-interface{
+        background: $color-nuetral;
+
+        &-wrapper {
+            margin: $section-margin 0;
+        }
+
+        &_tab-wrapper {
+            display:flex;
+            background:$color-light;
+        }
+
+        &_tab-btn {
+            background: rgba($color-dark, .65);
+            margin-right:5px;
+            width:150px;
+            border: 2px solid $color-dark;
+            border-bottom: 1px solid rgba($color-dark, .15);;
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
+            &:hover {
+                background: rgba($color-dark, .8);
+            }
+            &.active {
+               background: $color-dark;  
+              &:hover {
+                background: $color-dark;  
+              }
+            }
+        }
+
+        &_action-bar {
+            display: flex;
+            justify-content: flex-end;
+            align-items: center;
+            background-color: $color-dark;     
+        }
+        &_action-btn {
+            padding: 0 10px;
+            font-size: 12px;
+            margin:5px;
+        }
+        
+        &_cell {
+                &:first-of-type {
+                    text-align: left;
+                    flex: 1 1 auto;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    flex-wrap: nowrap;
+                }
+                &:last-of-type {
+                    flex: 0 0 100px;
+                }
+                
+            }
+
+        
+    }
+
     &_card-view {
         display:none;
         &.active {
             display:block;
         }
     }
+
+
+
     &_collection {
-        margin-top: $section-margin;
-
-        &_heading-bar {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-
-            &-title {
-                margin: 0
-            }
-
-            &_edit-btn {
-                justify-self: end;
-                padding: 0 10px;
-                font-size: 12px;
-            }
-        }
-
-        &-cell {
-            flex: 0 0 60px;
+       
+        &_cell {
+            flex: 0 0 100px;
             text-align: center;
-
 
             &:first-of-type {
                 text-align: left;
@@ -142,7 +187,6 @@
                 text-overflow: ellipsis;
                 flex-wrap: nowrap;
             }
-
             &:last-of-type {
                 flex: 0 0 100px;
             }

--- a/app/assets/stylesheets/login/login.scss
+++ b/app/assets/stylesheets/login/login.scss
@@ -16,6 +16,7 @@
     &-content {
         width: 40%;
         min-width: 295px;
+        max-width: 400px;
         background: rgba($color-light, .9);
         padding: $section-padding;
         text-align: center;

--- a/app/assets/stylesheets/login/login.scss
+++ b/app/assets/stylesheets/login/login.scss
@@ -8,6 +8,7 @@
     align-items: center;
     justify-content: center;
     text-align: center;
+
     &-title {
         margin-top: 0;
     }
@@ -21,12 +22,19 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-
-        &_form-field {
-            margin: 5px 0;
-        }
-
     }
+
+    &_form-field {
+        margin: 5px 0;
+
+        input[type=checkbox]+label:before {
+            margin-right: 5px;
+            margin-top: -2px;
+            margin-bottom: 2px;
+        }
+    }
+
+
 
     [class*="-btn"] {
         margin: 5px auto;
@@ -34,6 +42,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
+
         svg {
             margin-right: 2px;
         }
@@ -41,7 +50,8 @@
 
     &_link-btn {
         background: $color-nuetral;
-        &:hover{
+
+        &:hover {
             background: darken($color-nuetral, 25%);
         }
     }

--- a/app/assets/stylesheets/sitewide/alert.scss
+++ b/app/assets/stylesheets/sitewide/alert.scss
@@ -1,6 +1,8 @@
 .alert{
     width: 120%;
     left: -10%;
+    align-items: center;
+    justify-content: center;
     top: $nav-height;
     position: absolute;
     color: $color-light;
@@ -9,9 +11,10 @@
     display: none;
     padding: 10px;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12), 0 1px 5px 0 rgba(0, 0, 0, 0.2);
-  
+
     &_close-button {
       position: relative;
+      background: transparent;
       color: $color-light;
       margin-left: 10px;
       top: initial;
@@ -20,7 +23,7 @@
     }
   
     &.active {
-      display: block;
+      display: flex;
     }
   
     &.logged-out {
@@ -29,5 +32,9 @@
   
     &.urgent {
       background-color: $color-highlight-urgent;
+    }
+    @media only screen and (max-width: 650px) {
+      width:100%;
+      left:0;
     }
   }

--- a/app/assets/stylesheets/sitewide/modal.scss
+++ b/app/assets/stylesheets/sitewide/modal.scss
@@ -32,8 +32,8 @@
     }
 
     &_close-button{
-        right:-6px;
-        top: 0px;
+        right:-5px;
+        top: -5px;
     }
 
     form {

--- a/app/assets/stylesheets/sitewide/sitewide.scss
+++ b/app/assets/stylesheets/sitewide/sitewide.scss
@@ -444,7 +444,7 @@ input[type=checkbox] {
     content: '\2713';
     position: absolute;
     left: 0px;
-    top: -1px;
+    top: 0px;
     font-size: $box-size;
     display: flex;
     line-height: $box-size;

--- a/app/assets/stylesheets/sitewide/sitewide.scss
+++ b/app/assets/stylesheets/sitewide/sitewide.scss
@@ -444,7 +444,7 @@ input[type=checkbox] {
     content: '\2713';
     position: absolute;
     left: 0px;
-    top: 0px;
+    top: -1px;
     font-size: $box-size;
     display: flex;
     line-height: $box-size;

--- a/app/assets/stylesheets/sitewide/sitewide.scss
+++ b/app/assets/stylesheets/sitewide/sitewide.scss
@@ -433,7 +433,8 @@ input[type=checkbox] {
     align-items: center;
     width: $checkbox-size;
     height: $checkbox-size;
-    background: rgba(255, 111, 97, 0.50);
+    background: transparent;
+    border: 2px solid rgba(255, 111, 97, 0.75);
     -webkit-tap-highlight-color: transparent;
     transition: .25s;
   }
@@ -472,6 +473,7 @@ input[type=checkbox] {
    // Disabled box.
    &:disabled+label:before {
     box-shadow: none;
+    border: 2px solid rgba(255, 111, 97, 0.25);
     background: rgba($color-nuetral, .25);
   }
 

--- a/app/assets/stylesheets/sitewide/sitewide.scss
+++ b/app/assets/stylesheets/sitewide/sitewide.scss
@@ -399,7 +399,66 @@ textarea.materialize-textarea[readonly="readonly"]+label {
 }
 
 input[type=checkbox] {
-  display: none;
+  position: absolute; // take it out of document flow
+  opacity: 0; // hide it
+
+  &+label {
+    position: relative;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  // Box.
+  &+label:before {
+    content: '';
+    display: inline-block;
+    vertical-align: text-top;
+    width: 20px;
+    height: 20px;
+    background: rgba($color-highlight-mid-import, .75);
+  }
+
+  // Box hover
+  &:hover+label:before {
+    background: $color-highlight-mid-import;
+  }
+
+  // Box checked
+  &:checked+label:before {
+    background: $color-highlight-import;
+  }
+
+  // Disabled state label.
+  &:disabled+label {
+    color: $color-nuetral;
+    cursor: auto;
+  }
+
+  &:checked+label:after {
+    content: '\2713';
+    position: absolute;
+    left: 0px;
+    top: -1px;
+    font-size: 20px;
+    display: flex;
+    line-height: 20px;
+    width: 20px;
+    height: 20px;
+    align-items: center;
+    justify-content: center;
+    color: white;
+  }
+   // Disabled box.
+   &:disabled+label:before {
+    box-shadow: none;
+    background: rgba($color-nuetral, .25);
+  }
+
+  &:disabled+label:after {
+    box-shadow: none;
+    color: $color-dark
+  }
+
 }
 
 //switch 
@@ -477,7 +536,7 @@ input[type=checkbox] {
     box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
   }
 
- 
+
 }
 
 //Overlays for modals and drawers
@@ -504,6 +563,7 @@ input[type=checkbox] {
   [class*="-section"] {
     padding-left: 1px;
     padding-right: 1px;
+
     &.full-page {
       padding: 5px;
     }

--- a/app/assets/stylesheets/sitewide/sitewide.scss
+++ b/app/assets/stylesheets/sitewide/sitewide.scss
@@ -401,6 +401,7 @@ textarea.materialize-textarea[readonly="readonly"]+label {
 input[type=checkbox] {
   position: absolute; // take it out of document flow
   opacity: 0; // hide it
+  $box-size: 20px;
 
   &+label {
     position: relative;
@@ -411,11 +412,16 @@ input[type=checkbox] {
   // Box.
   &+label:before {
     content: '';
-    display: inline-block;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
     vertical-align: text-top;
-    width: 20px;
-    height: 20px;
-    background: rgba($color-highlight-mid-import, .75);
+    width: $box-size;
+    height: $box-size;
+    line-height: $box-size;
+    background: rgba(255, 111, 97, 0.50);
+    -webkit-tap-highlight-color: transparent;
+    transition: .25s;
   }
 
   // Box hover
@@ -439,14 +445,14 @@ input[type=checkbox] {
     position: absolute;
     left: 0px;
     top: -1px;
-    font-size: 20px;
+    font-size: $box-size;
     display: flex;
-    line-height: 20px;
-    width: 20px;
-    height: 20px;
+    line-height: $box-size;
+    width: $box-size;
+    height: $box-size;
     align-items: center;
     justify-content: center;
-    color: white;
+    color: $color-light;
   }
    // Disabled box.
    &:disabled+label:before {

--- a/app/assets/stylesheets/sitewide/sitewide.scss
+++ b/app/assets/stylesheets/sitewide/sitewide.scss
@@ -4,6 +4,7 @@ $footer-height: 32px;
 $section-padding: 25px;
 $section-margin: 25px;
 $animation-delay: 2s;
+$checkbox-size: 25px;
 
 //Text Treatments
 a {
@@ -124,6 +125,16 @@ ul {
       padding-left: 15px;
     }
   }
+}
+
+//Font awesome icon set up 
+
+.icon::before {
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
 }
 
 //General Site Structure
@@ -284,12 +295,17 @@ select {
 //TODO refactor close buttons to work with other button classes
 [class*="_close-button"] {
   position: absolute;
+  display:flex;
+  align-items: center;
+  justify-content: center;
   top: 5px;
   right: 5px;
-  color: $color-highlight-import;
+  width:30px;
+  height:30px;
+  background: $color-highlight-import;
+  color: $color-light;
   float: right;
   margin: 0;
-  background: transparent;
   border: none;
   cursor: pointer;
 
@@ -401,7 +417,7 @@ textarea.materialize-textarea[readonly="readonly"]+label {
 input[type=checkbox] {
   position: absolute; // take it out of document flow
   opacity: 0; // hide it
-  $box-size: 20px;
+
 
   &+label {
     position: relative;
@@ -415,10 +431,8 @@ input[type=checkbox] {
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    vertical-align: text-top;
-    width: $box-size;
-    height: $box-size;
-    line-height: $box-size;
+    width: $checkbox-size;
+    height: $checkbox-size;
     background: rgba(255, 111, 97, 0.50);
     -webkit-tap-highlight-color: transparent;
     transition: .25s;
@@ -441,15 +455,16 @@ input[type=checkbox] {
   }
 
   &:checked+label:after {
-    content: '\2713';
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
+    content: "\f00c";
     position: absolute;
     left: 0px;
-    top: -1px;
-    font-size: $box-size;
+    top: 0px;
+    font-size: calc#{$checkbox-size*.8};
     display: flex;
-    line-height: $box-size;
-    width: $box-size;
-    height: $box-size;
+    width: $checkbox-size;
+    height: $checkbox-size;
     align-items: center;
     justify-content: center;
     color: $color-light;

--- a/app/views/dashboard/_user_collections.html.erb
+++ b/app/views/dashboard/_user_collections.html.erb
@@ -1,4 +1,4 @@
-<div class="dashboard_collection">
+<div id="collection"class="dashboard_collection dashboard_card-view">
   <div class="dashboard_collection_heading-bar">
     <h3 class="dashboard_collection_heading-bar-title">Collection</h3>
     <%= link_to 'Edit', edit_collection_path(user.collection.id), class: 'dashboard_collection_heading-bar_edit-btn' if policy(user.collection).edit? %>

--- a/app/views/dashboard/_user_collections.html.erb
+++ b/app/views/dashboard/_user_collections.html.erb
@@ -26,7 +26,7 @@
     return `
     <div id="alert-container" class="active alert alert-${key}">
     ${value}
-          <a class="close-button" href="#" onclick="Helpers.toggleElementById('alert-container')" data-turbolinks="false">&#9650;</a>
+          <a class="close-button" href="#" onclick="Helpers.toggleElementById('alert-container')" data-turbolinks="false"><i class="fas fa-times"></i></a>
     </div>
     `
   };

--- a/app/views/dashboard/_user_collections.html.erb
+++ b/app/views/dashboard/_user_collections.html.erb
@@ -1,7 +1,6 @@
-<div id="collection"class="dashboard_collection dashboard_card-view">
-  <div class="dashboard_collection_heading-bar">
-    <h3 class="dashboard_collection_heading-bar-title">Collection</h3>
-    <%= link_to 'Edit', edit_collection_path(user.collection.id), class: 'dashboard_collection_heading-bar_edit-btn' if policy(user.collection).edit? %>
+<div id="collection"class="dashboard_collection dashboard_card-view active">
+  <div class="dashboard_card-interface_action-bar">
+    <%= link_to 'Edit', edit_collection_path(user.collection.id), class: 'dashboard_card-interface_action-btn' if policy(user.collection).edit? %>
   </div>
   <div class="dashboard_collection-table">
     <div class="dashboard_collection-row-headings">

--- a/app/views/dashboard/_user_collections.html.erb
+++ b/app/views/dashboard/_user_collections.html.erb
@@ -1,20 +1,18 @@
-<div id="collection"class="dashboard_collection dashboard_card-view active">
+<div id="collection" class="dashboard_card-view active">
   <div class="dashboard_card-interface_action-bar">
     <%= link_to 'Edit', edit_collection_path(user.collection.id), class: 'dashboard_card-interface_action-btn' if policy(user.collection).edit? %>
   </div>
-  <div class="dashboard_collection-table">
-    <div class="dashboard_collection-row-headings">
-      <div class="dashboard_collection-cell">Card</div>
-      <div class="dashboard_collection-cell">Amount</div>
-      <div class="dashboard_collection-cell">Tradable</div> 
+  <div class="dashboard_card-interface-table">
+    <div class="dashboard_card-view-row-headings">
+      <div class="dashboard_card-view-cell">Card</div>
+      <div class="dashboard_card-view-cell">Tradable</div> 
     </div>
     <% @cards.each do |card| %>
-    <div class="dashboard_collection-row">
-      <div class="dashboard_collection-cell"><%= card.name %></div>
-      <div class="dashboard_collection-cell"><%= @cards.count[card.id] %></div>
-      <div class="dashboard_collection-cell">
-        <input class="dashboard_collection_for-trade-toggle_checkbox" type="checkbox" <%= checked_if_tradable(@tradables, card) %> <%= disabled_if_not_current_user(user) %> data-id="<%= card.id %>" id="<%= "#{card.name}_#{card.id}" %>">
-        <label class="dashboard_collection_for-trade-toggle" for="<%= "#{card.name}_#{card.id}" %>"></label>
+    <div class="dashboard_card-view-row">
+      <div class="dashboard_card-view-cell"><%= card.name %></div>
+      <div class="dashboard_card-view-cell">
+        <input class="dashboard_tradable-toggle" type="checkbox" <%= checked_if_tradable(@tradables, card) %> <%= disabled_if_not_current_user(user) %> data-id="<%= card.id %>" id="<%= "#{card.name}_#{card.id}" %>">
+        <label class="dashboard_tradable-toggle" for="<%= "#{card.name}_#{card.id}" %>"></label>
       </div>
     </div>
     <% end %>
@@ -31,7 +29,7 @@
     `
   };
   $(function() {
-    $('.dashboard_collection_for-trade-toggle_checkbox').on('click', function() {
+    $('.tradable-toggle').on('click', function() {
       console.log($(this));
       id = $(this).attr('data-id');
       that = this;

--- a/app/views/dashboard/_user_collections.html.erb
+++ b/app/views/dashboard/_user_collections.html.erb
@@ -5,11 +5,13 @@
   <div class="dashboard_card-interface-table">
     <div class="dashboard_card-view-row-headings">
       <div class="dashboard_card-view-cell">Card</div>
+      <div class="dashboard_card-view-cell">Count</div>
       <div class="dashboard_card-view-cell">Tradable</div> 
     </div>
     <% @cards.each do |card| %>
     <div class="dashboard_card-view-row">
       <div class="dashboard_card-view-cell"><%= card.name %></div>
+      <div class="dashboard_card-view-cell"><%= @cards.count[card.id] %></div>
       <div class="dashboard_card-view-cell">
         <input class="dashboard_tradable-toggle" type="checkbox" <%= checked_if_tradable(@tradables, card) %> <%= disabled_if_not_current_user(user) %> data-id="<%= card.id %>" id="<%= "#{card.name}_#{card.id}" %>">
         <label class="dashboard_tradable-toggle" for="<%= "#{card.name}_#{card.id}" %>"></label>

--- a/app/views/dashboard/_user_collections.html.erb
+++ b/app/views/dashboard/_user_collections.html.erb
@@ -31,7 +31,7 @@
     `
   };
   $(function() {
-    $('.tradable-toggle').on('click', function() {
+    $('.dashboard_tradable-toggle').on('click', function() {
       console.log($(this));
       id = $(this).attr('data-id');
       that = this;

--- a/app/views/dashboard/_user_wishlist.html.erb
+++ b/app/views/dashboard/_user_wishlist.html.erb
@@ -1,4 +1,4 @@
-<div class="dashboard_wishlist">
+<div id="wishlist" class="dashboard_wishlist dashboard_card-view">
   <h3>Wishlist</h3>
    <div  class="dashboard_wishlist-table">
     <div class="dashboard_wishlist-row-headings">

--- a/app/views/dashboard/_user_wishlist.html.erb
+++ b/app/views/dashboard/_user_wishlist.html.erb
@@ -1,31 +1,30 @@
-<div id="wishlist" class="dashboard_wishlist dashboard_card-view">
+<div id="wishlist" class="dashboard_card-view">
 <div class="dashboard_card-interface_action-bar">
 <%= link_to 'Edit', edit_collection_path(user.collection.id), class: 'dashboard_card-interface_action-btn' if policy(user.collection).edit? %>
 </div>
-   <div  class="dashboard_wishlist-table">
-    <div class="dashboard_wishlist-row-headings">
-      <div class="dashboard_wishlist-cell">Card</div>
-      <div class="dashboard_wishlist-cell">Card</div>
-
-      <script>
+   <div id="wishlist-table" class="dashboard_card-view-table">
+    <div class="dashboard_card-view-row-headings">
+      <div class="dashboard_card-view-cell">Card</div>
+       <script>
         var cardRow = function(card) {
         if (<%=current_user.id%>===<%= @user.id %>){
         return `
-          <div class="dashboard_wishlist-row wishlist-item">
-            <div class="dashboard_wishlist-cell">
+          <div class="dashboard_card-view-row wishlist-item">
+            <div class="dashboard_card-view-cell">
               ${card.name}
             </div>
-            <div class="dashboard_wishlist-cell">
-               <button data-id="${card.id}" class="dashboard_wishlist_remove-btn" if policy(@user)?>Remove</button>
+            <div class="dashboard_card-view-cell">
+            <input class="dashboard_wishlist-toggle" type="checkbox" checked <%= disabled_if_not_current_user(user) %> data-id="${card.id}" id="${card.name}_${card.id}">
+            <label class="dashboard_wishlist-toggle" for="${card.name}_${card.id}"></label>
             </div>
           </div>
          `
         }
        else{
        return `
-          <div class="dashboard_wishlist-row wishlist-item">
-            <div class="dashboard_wishlist-cell">${card.name}</div>
-            <div class="dashboard_wishlist-cell"></div>
+          <div class="dashboard_card-view-row wishlist-item">
+            <div class="dashboard_card-view-cell">${card.name}</div>
+            <div class="dashboard_card-view-cell"></div>
           </div>
         `
         }
@@ -36,12 +35,12 @@
           xhrRequest('/wishlists/<%= @user.id %>', 'GET', function(res){
             $('.wishlist-item').remove()
             res.forEach(function(card) {
-              $('.dashboard_wishlist-table').append(cardRow(card));
+              $('#wishlist-table').append(cardRow(card));
             });
           });
 
-          $(document).off('click', '.dashboard_wishlist_remove-btn');
-          $(document).on('click', '.dashboard_wishlist_remove-btn', function(){
+          $(document).off('click', '.dashboard_wishlist-toggle');
+          $(document).on('click', '.dashboard_wishlist-toggle', function(){
             card_id = $(this).attr('data-id');
             that = this;
             $.ajax({
@@ -53,7 +52,7 @@
               data: { card_id: card_id },
               dataType: 'json',
               success: function(res) {
-                $(that).closest('.dashboard_wishlist-row').remove();
+                $(that).closest('.dashboard_card-view-row').remove();
               },
               error: function(res) {
               }

--- a/app/views/dashboard/_user_wishlist.html.erb
+++ b/app/views/dashboard/_user_wishlist.html.erb
@@ -1,6 +1,6 @@
 <div id="wishlist" class="dashboard_card-view">
 <div class="dashboard_card-interface_action-bar">
-<%= link_to 'Edit', edit_collection_path(user.collection.id), class: 'dashboard_card-interface_action-btn' if policy(user.collection).edit? %>
+<%= link_to 'Add', trades_path, class: 'dashboard_card-interface_action-btn' if policy(user.collection).edit? %>
 </div>
    <div id="wishlist-table" class="dashboard_card-view-table">
     <div class="dashboard_card-view-row-headings">

--- a/app/views/dashboard/_user_wishlist.html.erb
+++ b/app/views/dashboard/_user_wishlist.html.erb
@@ -1,8 +1,12 @@
 <div id="wishlist" class="dashboard_wishlist dashboard_card-view">
-  <h3>Wishlist</h3>
+<div class="dashboard_card-interface_action-bar">
+<%= link_to 'Edit', edit_collection_path(user.collection.id), class: 'dashboard_card-interface_action-btn' if policy(user.collection).edit? %>
+</div>
    <div  class="dashboard_wishlist-table">
     <div class="dashboard_wishlist-row-headings">
       <div class="dashboard_wishlist-cell">Card</div>
+      <div class="dashboard_wishlist-cell">Card</div>
+
       <script>
         var cardRow = function(card) {
         if (<%=current_user.id%>===<%= @user.id %>){

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -60,14 +60,3 @@
     </div>
   </div>
 </div>
-  <!--  Ranking Page Scripts-->
-  <!-- TO DO: STRIP THESE OUT INTO SEP FILES -->
-  <!--List animation cue-->
-  <script>
-    var ul = document.getElementById("rankings");
-    var items = ul.getElementsByTagName("a");
-    for (var i = 0; i < items.length; i++) {
-
-      items[i].style.animationDuration = .2 + (i / 3) + "s";
-    }
-  </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -136,7 +136,7 @@
       <div class="match-logger_overlay" onclick="Helpers.toggleElementById('match-logger')"></div>
       <div class="match-logger-section">
         <button href="#" class="match-logger_close-button" onclick="Helpers.toggleElementById('match-logger')">
-        <i class="fas fa-times"></i>
+         <i class="fas fa-times"></i>
         </button>
         <%= form_tag "/matches", method: "post", id: "match-logger" do %>
         

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
             <li class="nav_menu-link">
               <%= link_to "profile", user_path(current_user) %>
             </li>
-            <li class="nav_menu-list"><a class="drop-down-toggle" onclick="AppLayout.closeOtherDropDown(), Helpers.toggleElementById('dd-menu-cards')">Cards &#9660;</a> 
+            <li class="nav_menu-list"><a class="drop-down-toggle" onclick="Helpers.toggleElementById('dd-menu-cards', 'dropdown-content')">Cards &#9660;</a> 
               <ul id="dd-menu-cards" class="dropdown-content">
                   <li>
                     <a href="/trades">trades</a>
@@ -44,7 +44,7 @@
                 </li>             
               </ul>
             </li>         
-            <li class="nav_menu-list"><a class="drop-down-toggle" onclick="AppLayout.closeOtherDropDown(), Helpers.toggleElementById('dd-menu-league')">League &#9660;</a> 
+            <li class="nav_menu-list"><a class="drop-down-toggle" onclick="Helpers.toggleElementById('dd-menu-league', 'dropdown-content')">League &#9660;</a> 
               <ul id="dd-menu-league" class="dropdown-content">
                  <li>
                   <a href="/matches">Matches</a>
@@ -62,7 +62,7 @@
             </li>
             <% if current_user.admin? %>
               <li class="nav_menu-list">
-                <a class="drop-down-toggle" onclick="AppLayout.closeOtherDropDown(), Helpers.toggleElementById('dd-menu-admin')">Admin &#9660;</a>
+                <a class="drop-down-toggle" onclick="Helpers.toggleElementById('dd-menu-admin', 'dropdown-content')">Admin &#9660;</a>
                 <ul id="dd-menu-admin" class="dropdown-content">
                   <li><a href="/admin/matches">Matches</a></li>
                   <li><a href="/admin/users">Users</a></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csp_meta_tag %>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
+    <script src="https://kit.fontawesome.com/bf38c6b1c9.js" crossorigin="anonymous"></script>
     <title>Ogre the Leaguening</title>
 
     <!-- CSS  -->
@@ -126,7 +127,7 @@
       <% flash.each do |key, value| %>
         <div id="alert"  class="active alert alert-<%= key %> 
           <%= user_signed_in? ? '' : 'logged-out' %>"><%= value %>
-          <a class="alert_close-button" href="#" onclick="Helpers.toggleElementById('alert')" data-turbolinks="false">&#9650;</a></div>
+          <a class="alert_close-button" href="#" onclick="Helpers.toggleElementById('alert')" data-turbolinks="false"><i class="fas fa-times"></i></a></div>
       <% end %>
       <%= yield %>
     </div>
@@ -135,7 +136,7 @@
       <div class="match-logger_overlay" onclick="Helpers.toggleElementById('match-logger')"></div>
       <div class="match-logger-section">
         <button href="#" class="match-logger_close-button" onclick="Helpers.toggleElementById('match-logger')">
-          <i class="material-icons">cancel</i>
+        <i class="fas fa-times"></i>
         </button>
         <%= form_tag "/matches", method: "post", id: "match-logger" do %>
         

--- a/app/views/trades/index.html.erb
+++ b/app/views/trades/index.html.erb
@@ -17,8 +17,8 @@
   var wishlist = []
 
   xhrRequest('/wishlists/' + <%= current_user.id %>, 'GET', function(res) { wishlist = res; });
-  $(document).off('click', '.card-grid_wishlist-toggle_checkbox');
-  $(document).on('click', '.card-grid_wishlist-toggle_checkbox', function(){
+  $(document).off('click', '.card-grid_wishlist-toggle-checkbox');
+  $(document).on('click', '.card-grid_wishlist-toggle-checkbox', function(){
     card_id = $(this).attr('data-id');
     xhrRequest('/wishlists/<%= current_user.id %>', "PUT", function(res) {wishlist=res;}, {card_id: card_id});
   });
@@ -26,11 +26,12 @@
   var cardTemplate = function(card) {
     return `
     <div class="card-grid_card-wrapper">
-      <div class="card-grid_wishlist-toggle">
-        <input class="card-grid_wishlist-toggle_checkbox" wish-list-id="${search('id', card.attributes.id, wishlist) === undefined ? -1 : search('id', card.attributes.id, wishlist).id}" data-id="${card.attributes.id}" id="wl-checkbox-for-${card.attributes.id}" type="checkbox" ${search('id', card.attributes.id, wishlist) === undefined ? '' : 'checked' }>
-        <label for="wl-checkbox-for-${card.attributes.id}"></label>
-      </div>
+    
       <div class="card-grid_card">
+        <div class="card-grid_wishlist-toggle">
+          <input class="card-grid_wishlist-toggle-checkbox" wish-list-id="${search('id', card.attributes.id, wishlist) === undefined ? -1 : search('id', card.attributes.id, wishlist).id}" data-id="${card.attributes.id}" id="wl-checkbox-for-${card.attributes.id}" type="checkbox" ${search('id', card.attributes.id, wishlist) === undefined ? '' : 'checked' }>
+          <label class="card-grid_wishlist-toggle-label" for="wl-checkbox-for-${card.attributes.id}"></label>
+        </div>
         <img alt="${card.attributes.name}" title="${card.attributes.name}" src="${card.attributes.image_url}">
       </div>
       <div class="card-grid_trade-proposal">

--- a/app/views/trades/index.html.erb
+++ b/app/views/trades/index.html.erb
@@ -44,7 +44,7 @@
   var onlyUserOwningCardTemplate = function(card) {
     return `
       <button class="modal_close-button" href="#" onclick="Helpers.toggleElementById('trade-modal')">
-        <i class="material-icons">cancel</i>
+      <i class="fas fa-times"></i>
       </button>
       <h4 class="modal-title">Oh no!</h4>
       <p>You are the only user who owns this card. 😭</p>
@@ -54,7 +54,7 @@
   var cardModalTemplate = function(card) {
     return `
       <button class="modal_close-button" href="#" onclick="Helpers.toggleElementById('trade-modal')">
-        <i class="material-icons">cancel</i>
+      <i class="fas fa-times"></i>
       </button>
       <h4 class="modal-title" >Email Proposal</h4>
       <p>You are contacting:</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,19 +1,21 @@
 
-<div id="dashboard">
+<div id="dashboard" class="dashboard">
   <div class="dashboard-container">
     <h2 class="dashboard-title"><%= @user.name %></h2>
     <%= render 'dashboard/user_profile', user: @user %>
-    <div class="dashboard_card-interface">
-    <div>
-      <div class="dashboard_card-interface-toggle-btn" onclick="Helpers.toggleElementById('collection', 'dashboard_card-view')">
-      Collection
+    <div class="dashboard_card-interface-wrapper">
+      <div class="dashboard_card-interface_tab-wrapper">
+        <div id="collection-tab" class="dashboard_card-interface_tab-btn active" onclick="Helpers.toggleElementById('collection', 'dashboard_card-view'), Helpers.toggleElementById('collection-tab', 'dashboard_card-interface_tab-btn')">
+          Collection
+        </div>
+        <div id="wishlist-tab" class="dashboard_card-interface_tab-btn" onclick="Helpers.toggleElementById('wishlist', 'dashboard_card-view'), Helpers.toggleElementById('wishlist-tab', 'dashboard_card-interface_tab-btn')">
+          Wishlist
+        </div>
       </div>
-      <div class="dashboard_card-interface-toggle-btn" onclick="Helpers.toggleElementById('wishlist', 'dashboard_card-view')">
-      Wishlist
+      <div class="dashboard_card-interface">
+        <%= render 'dashboard/user_wishlist', user: @user %>
+        <%= render 'dashboard/user_collections', user: @user %>
       </div>
-    </div>
-    <%= render 'dashboard/user_wishlist', user: @user %>
-    <%= render 'dashboard/user_collections', user: @user %>
     </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,17 @@
   <div class="dashboard-container">
     <h2 class="dashboard-title"><%= @user.name %></h2>
     <%= render 'dashboard/user_profile', user: @user %>
+    <div class="dashboard_card-interface">
+    <div>
+      <div class="dashboard_card-interface-toggle-btn" onclick="Helpers.toggleElementById('collection', 'dashboard_card-view')">
+      Collection
+      </div>
+      <div class="dashboard_card-interface-toggle-btn" onclick="Helpers.toggleElementById('wishlist', 'dashboard_card-view')">
+      Wishlist
+      </div>
+    </div>
     <%= render 'dashboard/user_wishlist', user: @user %>
     <%= render 'dashboard/user_collections', user: @user %>
+    </div>
   </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "mtg-league",
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.13.0"
+  },
   "scripts": {
     "start-mac": "pg_ctl -D /usr/local/var/postgres start && rails s",
     "start-ubuntu": "sudo service postgresql start && rails s"


### PR DESCRIPTION
# Description

This pull takes our existing Dashboard and starts integrating some of the new layout ideas. Specifically, it sets up a tab-able container that houses our wishlist and collection tables.  Eventually, this will be the container that will display the card grid views for those same lists.  

This PR adds font awesome icons, to better deal with mobile special character display issues.

This does not add any functionality for the user, aside from quick link to the trades page where they can wishlist cards. 

## Scope

Profile pages 

## Out of Scope Changes 

Several areas of the site were refactored to work with the font-awesome icons, and new global checkbox styles, including: 

- log in screen stay logged in checkbox
- modal / match logger close button
- card grid wish list toggles

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

