### PR TITLE
Log Match date fix

### DIFF
--- a/app/assets/javascripts/app_layout.js
+++ b/app/assets/javascripts/app_layout.js
@@ -1,7 +1,10 @@
 var AppLayout = (function() {
   let setMatchDateAndTime = function() {
     let date  = new Date();
-    let today = date.toISOString().substr(0, 10);
+    let day = ('0' + date.getDate()).slice(-2); // Want to make sure 0 is included for values < 10
+    let month = ('0' + (date.getMonth() + 1)).slice(-2); // adding one since getMonth is zero-based (Jan is 0)
+    let year = date.getFullYear();
+    let today = `${year}-${month}-${day}`;
     let hour = ('0' + date.getHours()).slice(-2);
     let min= ('0' + date.getMinutes()).slice(-2);
     let time = `${hour}:${min}`;


### PR DESCRIPTION
AppLayout - setMatchDateAndTime - fix for issue when using toISOString (it uses UTC, which can cause the date to be a day in the future)

# Description

The date generated for use in the Log Match form could be a date 1 day in the future.  The cause for this is that the toISOString method will convert the date to UTC, which was unintended.  This is now generating the date string using other methods on the date object and then constructing the string with those parts.

##Scope

Log Match form.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
