### PR TITLE
Card text search update

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,6 +1,6 @@
 class CardsController < ApplicationController
   def index
-    cards = Card.query(params[:query]).order(:name)
+    cards = Card.query_all_text(params[:query]).order(:name)
     options = {params: {current_user: current_user}}
     respond_to do |format|
       format.js { render json: CardSerializer.new(cards, options).serialized_json }

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -4,5 +4,8 @@ class Card < ApplicationRecord
   has_many :users, -> { distinct },  through: :collections 
   has_many :tradables
   has_many :wishes
-  scope :query, ->(string) { where(arel_table[:name].matches("%#{sanitize_sql_like string}%")) }
+  scope :query_name, ->(string) { where(arel_table[:name].matches("%#{sanitize_sql_like string}%")) }
+  scope :query_oracle_text, ->(string) { where(arel_table[:oracle_text].matches("%#{sanitize_sql_like string}%")) }
+  scope :query_type_line, ->(string) { where(arel_table[:type_line].matches("%#{sanitize_sql_like string}%")) }
+  scope :query_all_text, ->(string) { query_name(string).or(query_oracle_text(string)).or(query_type_line(string)) }
 end

--- a/db/migrate/20200802225446_add_data_to_cards.rb
+++ b/db/migrate/20200802225446_add_data_to_cards.rb
@@ -1,0 +1,10 @@
+class AddDataToCards < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cards, :oracle_text, :string
+    add_column :cards, :type_line, :string
+    add_column :cards, :mana_cost, :string
+    add_column :cards, :cmc, :decimal
+    add_column :cards, :colors, :string, array: true, default: []
+    add_column :cards, :rarity, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_18_132658) do
+ActiveRecord::Schema.define(version: 2020_08_02_225446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,12 @@ ActiveRecord::Schema.define(version: 2020_04_18_132658) do
     t.string "set"
     t.string "image_url"
     t.string "multiverse_id"
+    t.string "oracle_text"
+    t.string "type_line"
+    t.string "mana_cost"
+    t.decimal "cmc"
+    t.string "colors", default: [], array: true
+    t.string "rarity"
   end
 
   create_table "collections", force: :cascade do |t|
@@ -58,7 +64,7 @@ ActiveRecord::Schema.define(version: 2020_04_18_132658) do
   end
 
   create_table "settings", force: :cascade do |t|
-    t.date "season_start_date", default: -> { "now()" }, null: false
+    t.date "season_start_date", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "season_length", default: 365, null: false
     t.integer "base_trade_sets", default: 1, null: false
     t.integer "bonus_trade_users", default: [], null: false, array: true
@@ -91,7 +97,7 @@ ActiveRecord::Schema.define(version: 2020_04_18_132658) do
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false, null: false
     t.integer "failed_attempts", default: 0, null: false
-    t.datetime "locked_at", default: -> { "now()" }
+    t.datetime "locked_at", default: -> { "CURRENT_TIMESTAMP" }
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/lib/tasks/get_cards.rake
+++ b/lib/tasks/get_cards.rake
@@ -12,6 +12,12 @@ namespace :cards do
         resource.image_url = card['image_uris']['png'] 
         resource.multiverse_id = card['multiverse_ids'].first
         resource.set = args[:set_code]
+        resource.oracle_text = card['oracle_text']
+        resource.type_line = card['type_line']
+        resource.mana_cost = card['mana_cost']
+        resource.cmc = card['cmc']
+        resource.colors = card['colors']
+        resource.rarity = card['rarity']
         resource.save!
       end
     end


### PR DESCRIPTION
Migration and Schema - added fields to cards
Card - added scopes to query the new text fields and all text
Cards Controller - Now querying all game text on the card

# Description

New data fields have been added to the cards table schema.  The card search functionality of the site will now search all of the game text associated with the card.  These fields are name, type_line, and oracle_text (which is the main block of rules text on a card).

Other fields were also brought in to facilitate future updates where we can further develop card filtering or display information card lists.

##Scope

What areas of the site does this effect

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
