### PR TITLE
get_cards - fix for setting multi-faced cards' image_url

### DIFF
--- a/lib/tasks/get_cards.rake
+++ b/lib/tasks/get_cards.rake
@@ -9,7 +9,7 @@ namespace :cards do
         puts "Processing #{card['name']}"
         resource = Card.find_or_create_by(name: card['name'])
         resource.description = card['text']
-        resource.image_url = card['image_uris']['png'] 
+        resource.image_url = card['card_faces'] ? card['card_faces'][0]['image_uris']['png'] : card['image_uris']['png']
         resource.multiverse_id = card['multiverse_ids'].first
         resource.set = args[:set_code]
         resource.oracle_text = card['oracle_text']


### PR DESCRIPTION
# Description

This is a fix for the get_cards rake task when setting the image_url for multi-faced cards.  Currently it errors out since it tries to access a property that doesn't exist when the card has multiple card faces.  This tests whether a card has a card_faces property and then will get the first of those images.

##Scope

Card table population rake task

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
