### PR TITLE
get_cards - followup fix for setting image_url...

### DIFF
--- a/lib/tasks/get_cards.rake
+++ b/lib/tasks/get_cards.rake
@@ -9,7 +9,18 @@ namespace :cards do
         puts "Processing #{card['name']}"
         resource = Card.find_or_create_by(name: card['name'])
         resource.description = card['text']
-        resource.image_url = card['card_faces'] ? card['card_faces'][0]['image_uris']['png'] : card['image_uris']['png']
+        if card['image_uris']
+          resource.image_url = card['image_uris']['png']
+        elsif card['card_faces']
+          first_face = card['card_faces'].first
+          if first_face['image_uris']
+            resource.image_url = first_face['image_uris']['png']
+          else
+            puts "Couldn't find an image_url for #{card['name']}"
+          end
+        else
+          puts "Couldn't find an image_url for #{card['name']}"
+        end
         resource.multiverse_id = card['multiverse_ids'].first
         resource.set = args[:set_code]
         resource.oracle_text = card['oracle_text']


### PR DESCRIPTION
…with multi-faced cards.  Not all multi-faced cards have separate image_uris!

# Description

This fix is for the case in which a card has multiple card faces, but doesn't have multiple image_uris.  This occurs when there are multiple cards/spells on the front face of the card.

##Scope

get_cards rake task

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
