### PR TITLE
Fix: browse modal interaction

### DIFF
--- a/app/javascript/components/CardBrowser/TradeProposalModal.jsx
+++ b/app/javascript/components/CardBrowser/TradeProposalModal.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Button from '../Button'
 import Modal from '../Modal';
 
 const OnlyYouOwnMsg = () => (

--- a/app/javascript/components/CardBrowser/TradeProposalModal.jsx
+++ b/app/javascript/components/CardBrowser/TradeProposalModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Button from '../Button'
+import Modal from '../Modal';
 
 const OnlyYouOwnMsg = () => (
   <>
@@ -25,20 +26,14 @@ const TradeProposalRequest = ({ users, card }) => (
   </>
 )
 
-const TradeProposalModal = ({ closeModal, card, currentUserId }) => {
-  const otherUsersWithCard =  card.attributes.users.data.filter(user => user.attributes.id !== currentUserId);
+const TradeProposalModal = ({ active, closeModal, card, currentUserId }) => {
+  const otherUsersWithCard =  card.attributes?.users.data.filter(user => user.attributes.id !== currentUserId) || [];
   return (
-    <div id="trade-modal" className="modal active"  >
-      <div className="modal__overlay overlay" onClick={closeModal}></div>
-      <div className="modal__content">
-        <Button className="modal__close-button" href="#" onClick={closeModal}>
-          <i className="fas fa-times"></i>
-        </Button>
+    <Modal onClose={closeModal} active={active}>
         {otherUsersWithCard.length > 0 ?
           <TradeProposalRequest users={otherUsersWithCard} card={card} />
           : <OnlyYouOwnMsg />}
-      </div>
-    </div>
+    </Modal>
   )
 }
 

--- a/app/javascript/components/CardBrowser/TradeProposalModal.jsx
+++ b/app/javascript/components/CardBrowser/TradeProposalModal.jsx
@@ -26,10 +26,10 @@ const TradeProposalRequest = ({ users, card }) => (
   </>
 )
 
-const TradeProposalModal = ({ active, closeModal, card, currentUserId }) => {
+const TradeProposalModal = ({ closeModal, card, currentUserId }) => {
   const otherUsersWithCard =  card.attributes?.users.data.filter(user => user.attributes.id !== currentUserId) || [];
   return (
-    <Modal onClose={closeModal} active={active}>
+    <Modal onClose={closeModal}>
         {otherUsersWithCard.length > 0 ?
           <TradeProposalRequest users={otherUsersWithCard} card={card} />
           : <OnlyYouOwnMsg />}

--- a/app/javascript/components/CardBrowser/TradeProposalModal.jsx
+++ b/app/javascript/components/CardBrowser/TradeProposalModal.jsx
@@ -27,7 +27,7 @@ const TradeProposalRequest = ({ users, card }) => (
 )
 
 const TradeProposalModal = ({ closeModal, card, currentUserId }) => {
-  const otherUsersWithCard =  card.attributes?.users.data.filter(user => user.attributes.id !== currentUserId) || [];
+  const otherUsersWithCard =  card.attributes.users.data.filter(user => user.attributes.id !== currentUserId);
   return (
     <Modal onClose={closeModal}>
         {otherUsersWithCard.length > 0 ?

--- a/app/javascript/components/Modal/index.jsx
+++ b/app/javascript/components/Modal/index.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import classNames from 'classnames';
+import Button from '../Button';
+
+const Modal = ({ onClose, children }) => {
+  return createPortal(
+    <div className="modal active">
+      <div className="modal__overlay overlay" onClick={onClose}></div>
+      <div className="modal__content">
+          <Button className="modal__close-button" onClick={onClose}>
+            <i className="fas fa-times"></i>
+          </Button>
+        {children}
+      </div>
+    </div>, document.body)
+}
+
+export default Modal;

--- a/app/javascript/components/Modal/index.jsx
+++ b/app/javascript/components/Modal/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
-import classNames from 'classnames';
 import Button from '../Button';
 
 const Modal = ({ onClose, children }) => {


### PR DESCRIPTION
# Description

Prior to this update, the card grid would reset when you closed the trade proposal modal in browse cards view. This annoyed me greatly. So I fixed it.

The fix was really just to remove the `href="#"` from the button but, in trying to figure out what this bug was, I created a reusable modal that is more reusable and follows proper portal patterns. So, you're welcome.

##Scope

What areas of the site does this effect

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
