### PR TITLE
feat: card grid scroll restoration

### DIFF
--- a/app/javascript/components/Dashboard/index.jsx
+++ b/app/javascript/components/Dashboard/index.jsx
@@ -77,7 +77,7 @@ const Dashboard = ({
   }, [activeTab, isListView]);
 
   return (
-    <div className="dashboard__card-interface-wrapper">
+    <div className="dashboard__card-interface-wrapper" data-preserve-scroll="true">
       <div className="dashboard__tab-wrapper">
         {Object.keys(Tabs).map((tabName) => (
           <InterfaceTab

--- a/app/javascript/helpers/scroll-restoration/index.js
+++ b/app/javascript/helpers/scroll-restoration/index.js
@@ -1,0 +1,24 @@
+/* eslint-disable no-undef */
+
+document.addEventListener('turbolinks:before-visit', () => {
+  if (document.querySelector('*[data-preserve-scroll=true]')) {
+    Turbolinks.savedScrolls = {
+      [window.location.href]: {
+        scrollTo: document.documentElement.scrollTop,
+      },
+    };
+  }
+});
+
+document.addEventListener('turbolinks:render', () => {
+  const savedScroll = Turbolinks.savedScrolls?.[window.location.href];
+  if (!savedScroll) { return; }
+
+  delete Turbolinks.savedScrolls[window.location.href];
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      window.scrollTo({ top: savedScroll.scrollTo });
+    });
+  });
+});

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -17,6 +17,7 @@
 import Rails from '@rails/ujs';
 import Turbolinks from 'turbolinks';
 import * as ActiveStorage from '@rails/activestorage';
+import '../helpers/scroll-restoration';
 
 Rails.start();
 Turbolinks.start();


### PR DESCRIPTION
# Description

Turbolinks and react do not play nicely together. So, I had to hamfist a solution to maintain scrolling on the card grid. This is probably the only area we will run into this problem for now.

##Scope

What areas of the site does this effect

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
