### PR TITLE
fix: match logger ios expects only hours and minutes

### DIFF
--- a/app/javascript/components/Navigation/MatchLogger/index.jsx
+++ b/app/javascript/components/Navigation/MatchLogger/index.jsx
@@ -9,7 +9,7 @@ const MatchLogger = ({ unlockedUsers, currentUserId }) => {
   const [playerA, setPlayerA] = useState(currentUserObject);
   const [playerB, setPlayerB] = useState(currentUserObject);
   const [selectedDate, setSelectedDate] = useState(new Date().toLocaleDateString('en-CA'));
-  const [selectedTime, setSelectedTime] = useState(new Date().toLocaleTimeString('en-US', { hour12: false }));
+  const [selectedTime, setSelectedTime] = useState(new Date().toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' }));
 
   return (
     <form id="match-logger" action="/matches" acceptCharset="UTF-8" method="post">


### PR DESCRIPTION
# Description

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString#using_options
##Scope

What areas of the site does this effect

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
