### PR TITLE
chore: multiplayer db setup

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -2,16 +2,20 @@ class MatchesController < ApplicationController
   def create
     date_time = DateTime.strptime(match_params[:date]+ " " + match_params[:time], "%Y-%m-%d %H:%M")
     loser = ([match_params[:playerA], match_params[:playerB]] - [match_params[:winner]]).first
-    Match.create(winner_id: match_params[:winner], loser_id: loser, played_at: date_time)
+    match = Match.create(played_at: date_time, participants: 2)
+    Result.create(match_id: match.id, user_id: match_params[:winner], place: 1)
+    Result.create(match_id: match.id, user_id: loser, place: 2)
     redirect_to :root
   end
 
   
   def index
-    @matches = Match.order('played_at DESC').map { |match| 
+    @matches = Match.order('played_at DESC').map { |match|
+      winner = match.get_user_in_place(1)
+      loser = match.get_user_in_place(2)
       OpenStruct.new({
-        winner: match.winner.name,
-        loser: match.loser.name,
+        winner: winner.name,
+        loser: loser.name,
         date: match.played_at.strftime("%a %b #{match.played_at.day.ordinalize}"),
         time: match.played_at.strftime("%I:%M%p"),
         id: match.id

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,10 +1,18 @@
 class Match < ApplicationRecord
   scope :played_during_month, ->(date) { where(played_at: date.beginning_of_month..date.end_of_month) }
 
-  has_many :records
-  has_many :users, through: :records
+  has_many :results
+  has_many :users, through: :results
 
   validates :participants, numericality: { greater_than_or_equal_to: 2 }, presence: true
   validates :played_at, presence: true
+
+  def get_user_in_place(place)
+    Result.where('match_id = ? AND place = ?', id, place).first.user
+  end
+
+  def users_in_match
+    Result.where('match_id = ?', id).map{ |result| result.user }
+  end
 
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -1,9 +1,10 @@
 class Match < ApplicationRecord
   scope :played_during_month, ->(date) { where(played_at: date.beginning_of_month..date.end_of_month) }
 
-  belongs_to :winner, class_name: 'User', foreign_key: 'winner_id'
-  belongs_to :loser, class_name: 'User', foreign_key: 'loser_id'
+  has_many :records
+  has_many :users, through: :records
 
-  validates :winner, :loser, :played_at, presence: true
+  validates :participants, numericality: { greater_than_or_equal_to: 2 }, presence: true
+  validates :played_at, presence: true
 
 end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,0 +1,10 @@
+class Result < ApplicationRecord
+  
+  belongs_to :match, class_name: 'Match', foreign_key: 'match_id'
+  has_one :user
+
+  validates :place, numericality: { 
+    greater_than: 0,
+    less_than_or_equal_to: ->(result) {result.match.participants}
+  }
+end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,7 +1,7 @@
 class Result < ApplicationRecord
   
   belongs_to :match, class_name: 'Match', foreign_key: 'match_id'
-  has_one :user
+  belongs_to :user, class_name: 'User', foreign_key: 'user_id'
 
   validates :place, numericality: { 
     greater_than: 0,

--- a/app/service_objects/player_ranker.rb
+++ b/app/service_objects/player_ranker.rb
@@ -17,10 +17,10 @@ class PlayerRanker
   private
 
   def has_played_any_matches?(user)
-    @matches.select { |m| m.winner_id == user.id || m.loser_id == user.id }.any?
+    users_in_match = @matches.select{ |m|m.users_in_match.any? { |u| u.id == user.id }}.any?
   end
 
   def serialize(ranking)
-    OpenStruct.new({name:ranking.user.name, id: ranking.user.id, ranking: ranking.elo.round(2), wins: @matches.select{ |m| m.winner_id == ranking.user.id }.count,  losses: @matches.select { |m| m.loser_id == ranking.user.id }.count}) 
+    OpenStruct.new({name:ranking.user.name, id: ranking.user.id, ranking: ranking.elo.round(2), wins: @matches.select{ |m| m.get_user_in_place(1).id == ranking.user.id }.count,  losses: @matches.select { |m| m.get_user_in_place(2).id == ranking.user.id }.count}) 
   end
 end

--- a/app/service_objects/ranking_engine.rb
+++ b/app/service_objects/ranking_engine.rb
@@ -18,8 +18,8 @@ class RankingEngine
   private 
 
   def generate_elo_for_match(match, rankings)
-    winner = rankings.find{|ranking| ranking.user.id == match.winner_id }
-    loser = rankings.find{|ranking| ranking.user.id == match.loser_id }
+    winner = rankings.find{|ranking| ranking.user.id == match.get_user_in_place(1).id }
+    loser = rankings.find{|ranking| ranking.user.id == match.get_user_in_place(2).id }
     r1 = 10**(winner.elo / 400.0)
     r2 = 10**(loser.elo / 400.0)
     e1 = r1 / (r1 + r2)

--- a/db/migrate/20220530144839_create_matches_and_results_relationship.rb
+++ b/db/migrate/20220530144839_create_matches_and_results_relationship.rb
@@ -1,0 +1,28 @@
+class CreateMatchesAndResultsRelationship < ActiveRecord::Migration[5.2]
+  def up
+    create_table :results do |t|
+      t.belongs_to :match
+      t.integer    :user_id
+      t.integer    :place 
+    end
+
+    execute <<-SQL
+      INSERT INTO Results (match_id, user_id, place)
+        SELECT id, winner_id, 1
+        FROM Matches;
+      INSERT INTO Results (match_id, user_id, place)
+        SELECT id, loser_id, 2
+        FROM Matches;
+    SQL
+
+    add_column :matches, :participants, :integer
+    Match.reset_column_information
+    Match.update_all(participants: 2)
+  end
+
+  def down
+    remove_column :matches, :participants
+
+    drop_table :results
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_02_185418) do
+ActiveRecord::Schema.define(version: 2022_05_30_144839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2022_05_02_185418) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "played_at"
+    t.integer "participants"
   end
 
   create_table "ownerships", force: :cascade do |t|
@@ -72,6 +73,13 @@ ActiveRecord::Schema.define(version: 2022_05_02_185418) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_received_trades_on_user_id"
+  end
+
+  create_table "results", force: :cascade do |t|
+    t.bigint "match_id"
+    t.integer "user_id"
+    t.integer "place"
+    t.index ["match_id"], name: "index_results_on_match_id"
   end
 
   create_table "settings", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,13 +54,29 @@ Ownership.find_or_create_by(card_id: card1.id, collection_id: dustin.collection.
 
 # Matches 
 # ==================================================
-Match.find_or_create_by(winner: pat, loser: zack, played_at: Time.now)
-Match.find_or_create_by(winner: pat, loser: dustin, played_at: Time.now)
-Match.find_or_create_by(winner: dustin, loser: zack, played_at: Time.now)
-Match.find_or_create_by(winner: pat, loser: dustin, played_at: Time.now)
-Match.find_or_create_by(winner: zack, loser: dustin, played_at: Time.now)
-Match.find_or_create_by(winner: zack, loser: pat, played_at: Time.now)
-Match.find_or_create_by(winner: zack, loser: dustin, played_at: Time.now)
+match1 = Match.find_or_create_by(played_at: Time.now, participants: 2)
+Result.find_or_create_by(match: match1, user: pat, place: 1)
+Result.find_or_create_by(match: match1, user: zack, place:2)
+
+match2 = Match.find_or_create_by(played_at: Time.now, participants: 2)
+Result.find_or_create_by(match: match2, user: dustin, place: 1)
+Result.find_or_create_by(match: match2, user: zack, place:2)
+
+match3 = Match.find_or_create_by(played_at: Time.now, participants: 2)
+Result.find_or_create_by(match: match3, user: pat, place: 1)
+Result.find_or_create_by(match: match3, user: dustin, place:2)
+
+match4 = Match.find_or_create_by(played_at: Time.now, participants: 2)
+Result.find_or_create_by(match: match4, user: zack, place: 1)
+Result.find_or_create_by(match: match4, user: dustin, place: 2)
+
+match5 = Match.find_or_create_by(played_at: Time.now, participants: 2)
+Result.find_or_create_by(match: match5, user: zack, place: 1)
+Result.find_or_create_by(match: match5, user: pat, place: 2)
+
+match6 = Match.find_or_create_by(played_at: Time.now, participants: 2)
+Result.find_or_create_by(match: match6, user: zack, place: 1)
+Result.find_or_create_by(match: match6, user: dustin, place: 2)
 
 # Trades
 # ===================================================

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Result, type: :model do
+  it 'should fail when passed a placement of less than 0' do
+    match = Match.new(participants: 4, played_at: nil)
+    result = Result.new(match: match, user: nil, place: -1)
+    expect(result).to_not be_valid
+  end
+
+  it 'should fail when passed a placement of greater than number of match participants' do
+    match = Match.new(participants: 4, played_at: nil)
+    result = Result.new(match: match, user: nil, place: 5)
+    expect(result).to_not be_valid
+  end
+
+  it 'should be valid with valid params' do
+    match = Match.new(participants: 4, played_at: nil)
+    result = Result.new(match: match, user: nil, place: 3)
+    expect(result).to be_valid
+  end
+end

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -1,21 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Result, type: :model do
+  user = User.new()
   it 'should fail when passed a placement of less than 0' do
     match = Match.new(participants: 4, played_at: nil)
-    result = Result.new(match: match, user: nil, place: -1)
+    result = Result.new(match: match, user: user, place: -1)
     expect(result).to_not be_valid
   end
 
   it 'should fail when passed a placement of greater than number of match participants' do
     match = Match.new(participants: 4, played_at: nil)
-    result = Result.new(match: match, user: nil, place: 5)
+    result = Result.new(match: match, user: user, place: 5)
     expect(result).to_not be_valid
   end
 
   it 'should be valid with valid params' do
     match = Match.new(participants: 4, played_at: nil)
-    result = Result.new(match: match, user: nil, place: 3)
+    result = Result.new(match: match, user: user, place: 3)
     expect(result).to be_valid
   end
 end

--- a/spec/service_objects/player_ranker_spec.rb
+++ b/spec/service_objects/player_ranker_spec.rb
@@ -1,15 +1,26 @@
 require 'rspec_helper'
 
 describe 'PlayerRanker' do
+  
+  before do
+    @zack = double(id: 1, name: 'Zack')
+    @guy = double(id: 3, name: 'Guy')
+    @pat = double(id: 2, name: 'Pat')
+    @match = double()
+    allow(@match).to receive(:get_user_in_place).with(1).and_return(@zack)
+    allow(@match).to receive(:get_user_in_place).with(2).and_return(@guy)
+    allow(@match).to receive(:users_in_match).and_return([@zack, @guy])
+  end
+
   it 'returns the ranked players' do
-    rankings = [double(user: double(id: 1, name: 'Zack'), elo: 1216), double(user: double(id: 2, name: 'Pat'))]
-    matches = [double(winner_id: 1, loser_id: 3)]
+    rankings = [double(user: @zack, elo: 1216), double(user: @pat)]
+    matches = [@match]
     expect(PlayerRanker.new(matches, rankings).ranked_players.count).to eq(1)
     expect(PlayerRanker.new(matches, rankings).ranked_players.first.name).to eq('Zack')
   end
   it 'returns the unranked players' do
-    rankings = [double(user: double(id: 1, name: 'Zack'), elo: 1216), double(user: double(id: 2, name: 'Pat'), elo: 1200)]
-    matches = [double(winner_id: 1, loser_id: 3)]
+    rankings = [double(user: @zack, elo: 1216), double(user: @pat, elo: 1200)]
+    matches = [@match]
     expect(PlayerRanker.new(matches, rankings).unranked_players.count).to eq(1)
     expect(PlayerRanker.new(matches, rankings).unranked_players.first.name).to eq('Pat')
   end

--- a/spec/service_objects/ranking_engine_spec.rb
+++ b/spec/service_objects/ranking_engine_spec.rb
@@ -1,17 +1,33 @@
 require 'rspec_helper'
 
 describe 'RankingEngine' do
+  before do
+    @zack = double(id: 1, name: 'Zack')
+    @pat = double(id: 2, name: 'Pat')
+   
+    @match = double()
+    allow(@match).to receive(:get_user_in_place).with(1).and_return(@zack)
+    allow(@match).to receive(:get_user_in_place).with(2).and_return(@pat)
+    allow(@match).to receive(:users_in_match).and_return([@zack, @pat])
+
+    @second_match = double()
+    allow(@second_match).to receive(:get_user_in_place).with(1).and_return(@pat)
+    allow(@second_match).to receive(:get_user_in_place).with(2).and_return(@zack)
+    allow(@second_match).to receive(:users_in_match).and_return([@zack, @pat])
+  end
+
   it 'generates Elo for two users and one match' do
-    users = [double(id: 1), double(id: 2)]
-    matches = [double(winner_id: 1, loser_id: 2)]
+    users = [@zack, @pat]
+    matches = [@match]
     rankings = RankingEngine.new(users, matches).generate_rankings
 
     expect(rankings.find{|ranking| ranking.user.id == 1}.elo).to be > 1200
     expect(rankings.find{|ranking| ranking.user.id == 2}.elo).to be < 1200
   end
+
   it 'generates Elo for two users and two matches' do
-    users = [double(id: 1), double(id: 2)]
-    matches = [double(winner_id: 1, loser_id: 2), double(winner_id: 2, loser_id: 1)]
+    users = [@zack, @pat]
+    matches = [@match, @second_match]
     rankings = RankingEngine.new(users, matches).generate_rankings
 
     expect(rankings.find{|ranking| ranking.user.id == 1}.elo).to be < 1205 


### PR DESCRIPTION
# Description

Currently, our matches are logged with only a single winner and loser id associated to the match. This PR modifies that model so that a match can contain any number of participants that each receive a "place" in the match. Moving to this model will help us support multiplayer matches in the future for different events or different game types.

##Scope

Match Logging
Ranking

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
