### PR TITLE
devise - trying to fix remember behavior.  I saw a post that indicate…

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -173,7 +173,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 1.year 
+  # config.timeout_in = 1.year 
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
# Description

devise - trying to fix remember behavior.  I saw a post that indicated that having both remember_for and timeout_in is unsupported, so commenting out timeout_in

##Scope

What areas of the site does this effect

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
