### PR TITLE
Menu 'Contact' item doesn't work as expected.  Removing for now

### DIFF
--- a/app/javascript/components/Navigation/index.jsx
+++ b/app/javascript/components/Navigation/index.jsx
@@ -42,11 +42,6 @@ const Navigation = ({ isAdmin, currentUserId, unlockedUsers }) => {
           displayName: 'Matches',
           href: 'matches',
         },
-
-        {
-          displayName: 'Contact',
-          href: 'mailto:ogretheleaguening@gmail.com?subject=From the Web App',
-        },
       ],
     },
 


### PR DESCRIPTION
# Description

Menu 'Contact Us' menu doesn't work as expected.  Removing for now, as it tries to route to a mailto link href

##Scope

Navigation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
