### PR TITLE
Rails 6.0 - enabling the rest of the new framework defaults

### DIFF
--- a/config/initializers/new_framework_defaults_6_0.rb
+++ b/config/initializers/new_framework_defaults_6_0.rb
@@ -14,17 +14,17 @@ Rails.application.config.action_view.default_enforce_utf8 = false
 #
 # This option is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.0.
-# Rails.application.config.action_dispatch.use_cookies_with_metadata = true
+Rails.application.config.action_dispatch.use_cookies_with_metadata = true
 
 # Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
-# Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
+Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
 
 # Return false instead of self when enqueuing is aborted from a callback.
-# Rails.application.config.active_job.return_false_on_aborted_enqueue = true
+Rails.application.config.active_job.return_false_on_aborted_enqueue = true
 
 # Send Active Storage analysis and purge jobs to dedicated queues.
-# Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
-# Rails.application.config.active_storage.queues.purge    = :active_storage_purge
+Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
+Rails.application.config.active_storage.queues.purge    = :active_storage_purge
 
 # When assigning to a collection of attachments declared via `has_many_attached`, replace existing
 # attachments instead of appending. Use #attach to add new attachments without replacing existing ones.
@@ -37,9 +37,9 @@ Rails.application.config.active_storage.replace_on_assign_to_many = true
 # If you send mail in the background, job workers need to have a copy of
 # MailDeliveryJob to ensure all delivery jobs are processed properly.
 # Make sure your entire app is migrated and stable on 6.0 before using this setting.
-# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
 # Enable the same cache key to be reused when the object being cached of type
 # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)
 # of the relation's cache key into the cache version to support recycling cache key.
-# Rails.application.config.active_record.collection_cache_versioning = true
+Rails.application.config.active_record.collection_cache_versioning = true


### PR DESCRIPTION
# Description

Rails 6.0 - enabling the rest of the new framework defaults

When this is deployed and can be verified it doesn't break existing functionality, we can fully switch over to the new framework defaults

##Scope

Config

## Type of change
- [x] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
