### PR TITLE
TradeProposalModal - fixed use case when contacting one user

### DIFF
--- a/app/javascript/components/TradeProposal/TradeProposalModal.jsx
+++ b/app/javascript/components/TradeProposal/TradeProposalModal.jsx
@@ -23,6 +23,9 @@ const TradeProposalRequest = ({ users, card }) => (
     <form action="/trade_mail" method="post">
       <input type="hidden" name="authenticity_token" value={document.querySelector('meta[name="csrf-token"]').content} />
       <input type="hidden" name="trade[card_id]" value={card.id} />
+      { users.length === 1 && 
+        <input type="hidden" name="trade[user_id]" value={users[0].attributes.id} />
+      }
       <button type="submit" className="trade-modal_send__button button">Send Message</button>
     </form>
   </>


### PR DESCRIPTION
# Description

TradeProposalModal - fixed use case when attempting to send one person a trade email

The issue was that when attempting to send one user an email, the user_id form hidden input was not set.  So on the controller side it always thought it should send to everyone with the card since it didn't receive a user_id parameter.  This is more of a quick fix, but I feel the trade modals can and should be more explicit for what they're attempting to do in the props they're passing instead of inferring from the users attached to the card prop.

##Scope
TradeProposalModal

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
