### PR TITLE
application_controller - made Pundit include more specific per deprecation warning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Pundit
+  include Pundit::Authorization
   before_action :authenticate_user!, :set_users
   protect_from_forgery
 


### PR DESCRIPTION


# Description

application_controller - made Pundit include more specific per deprecation warning

##Scope

Authorization.  I noticed deprecation warnings in my local env about how Pundit was included and it should be Pundit::Authorization instead.

## Type of change
- [x] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
