### PR TITLE
CardOwnership - add wishlisters table

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -9,21 +9,22 @@ class CardsController < ApplicationController
   
   def show
     @card = Card.find_by_id(params[:id])
-    @total_count = @card.ownerships.count
+    
     counts_by_id = Hash.new
     @card.ownerships.each do |o|
       counts_by_id[o.collection.user.id] ||= 0
       counts_by_id[o.collection.user.id] += 1
     end
     @owner_details = Hash.new
-    @card.ownerships.each do |o|
+    @card.ownerships.sort_by{ |o| o.collection.user.name }.each do |o|
       user = o.collection.user
       @owner_details[user.id] = {id: user.id, name: user.name, count: counts_by_id[user.id] }
     end
+
     @wishlisters_details = Hash.new
-    @card.wishes.each do |w|
+    @card.wishes.sort_by{ |w| w.user.name }.each do |w|
       user = w.user
-      @wishlisters_details[user.id] = { id: user.id, name: user.name }
+      @wishlisters_details[user.id] = { id: user.id, name: user.name, count: counts_by_id[user.id] ? counts_by_id[user.id] : 0 }
     end
   end
 

--- a/app/javascript/components/CardOwnership/OwnershipTable.jsx
+++ b/app/javascript/components/CardOwnership/OwnershipTable.jsx
@@ -13,9 +13,9 @@ const OwnershipTable = ({
   card, currentUserId, totalCount, ownerDetails,
 }) => (
   <>
-    <Table>
+    <Table className="card-profile__table--ownership">
       <Row className="card-profile__row--headings" isHeading>
-        <Cell isPriority>Owner</Cell>
+        <Cell isPriority>Owned By</Cell>
         <AmountCell>Amount</AmountCell>
       </Row>
       {totalCount <= 0 ? <NoOwnersMessage /> : (
@@ -34,8 +34,13 @@ const OwnershipTable = ({
           </Row>
         ))
       )}
+      {totalCount > 0 && 
+        <Row>
+          <Cell isPriority><b><i>Total</i></b></Cell>
+          <AmountCell><b><i>{totalCount}</i></b></AmountCell>
+        </Row>
+      }
     </Table>
-    <p>{`*total copies in league: ${totalCount}`}</p>
   </>
 );
 

--- a/app/javascript/components/CardOwnership/WishlistTable.jsx
+++ b/app/javascript/components/CardOwnership/WishlistTable.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Table, Row, Cell } from '../Table';
+
+const NoWishlistersMessage = () => <Cell isPriority>No one has put this card on their wishlist yet</Cell>;
+
+const WishlistTable = ({
+  totalWishlisters, wishlisterDetails
+}) => (
+  <>
+    <Table>
+      <Row className="card-profile__row--headings" isHeading>
+        <Cell isPriority>Wishlisted By</Cell>
+        <Cell>Currently Owns</Cell>
+      </Row>
+    {totalWishlisters <= 0 ? <NoWishlistersMessage /> : (
+      wishlisterDetails.map(({ id, name, count }) => (
+        <Row>
+          <Cell isPriority><a href={`/users/${id}`}>{name}</a></Cell>
+          <Cell className="card-profile__cell--amount">{count}</Cell>
+        </Row>
+      ))
+    )}
+    </Table>
+  </>
+);
+
+export default WishlistTable;

--- a/app/javascript/components/CardOwnership/index.jsx
+++ b/app/javascript/components/CardOwnership/index.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import OwnershipTable from './OwnershipTable';
+import WishlistTable from './WishlistTable';
 import { TradeProposalButtonLarge } from '../TradeProposal';
 import formatCard from './format-card';
 import WishlistToggleLarge from '../WishlistToggle/WishlistToggleLarge';
 import { CardImage } from '../CardGrid';
 
 const CardOwnership = ({
-  card, currentUserId, totalCount, ownerDetails, wishlist,
+  card, currentUserId, totalCount, ownerDetails, wishlist, totalWishlisters, wishlisterDetails
 }) => {
   const isWishlisted = wishlist[currentUserId] !== undefined;
   return (
@@ -15,7 +16,11 @@ const CardOwnership = ({
         {card.name}
       </h3>
       <div className="card-profile__card">
-        <div style={{ maxWidth: '220px', margin: 'auto' }}>
+        {/*
+          The below style seems to override what's in card-profile.scss for the above className
+          When the below style is removed, card image is as large as it seemingly can be
+        */}
+        <div style={{ maxWidth: '350px', margin: 'auto' }}>
           <CardImage name={card.name} imageUrl={card.image_url} />
         </div>
       </div>
@@ -37,6 +42,10 @@ const CardOwnership = ({
           currentUserId={currentUserId}
           totalCount={totalCount}
           ownerDetails={ownerDetails}
+        />
+        <WishlistTable
+          totalWishlisters={totalWishlisters}
+          wishlisterDetails={wishlisterDetails}
         />
       </div>
     </>

--- a/app/javascript/stylesheets/cards/card-profile.scss
+++ b/app/javascript/stylesheets/cards/card-profile.scss
@@ -102,4 +102,7 @@
         }
 
     }
+    &__table--ownership {
+        margin-bottom: 15px;
+    }
 }

--- a/app/views/cards/show.html.erb
+++ b/app/views/cards/show.html.erb
@@ -1,7 +1,9 @@
 <%= react_component("CardOwnership", {
         card: @card,
         wishlist: @wishlisters_details,
-        totalCount: @total_count,
+        totalCount: @owner_details.size,
         ownerDetails: @owner_details.collect { |key, value| value },
-        currentUserId: current_user.id
+        currentUserId: current_user.id,
+        totalWishlisters: @wishlisters_details.size,
+        wishlisterDetails: @wishlisters_details.collect { |key, value| value }
     }, {:class => "card-profile__container"}) %>


### PR DESCRIPTION
card - show: slightly modified to sort names and add info to wishlisters_details for display
CardOwnership: updated to also show wishlisters, slightly modified existing elements

# Description
Added table on card show/profile page to also show the users who have wishlisted the card.  Minor update to the owners table.

##Scope

card show action, CardOwnership files

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
