### PR TITLE
make quantity selector text color neutral

### DIFF
--- a/app/javascript/stylesheets/card-grid/card-grid.scss
+++ b/app/javascript/stylesheets/card-grid/card-grid.scss
@@ -115,6 +115,10 @@
             margin-bottom: 0;
             -moz-appearance: textfield;
             height:auto;
+            color: var(--color-text-neutral)
+        }
+        button {
+            color: var(--color-text-neutral)
         }
 
     }


### PR DESCRIPTION
# Description
Noticed that the black text in the card quantity updater was not contrasted enough. Changed it to be neutral coloring

Before Changes:
![image](https://github.com/OgreWebBros/magic-league/assets/2858570/9337a557-bbe7-4e9c-aa7c-0e81ba46b171)

After Changes:
![image](https://github.com/OgreWebBros/magic-league/assets/2858570/fcaa68f7-0f80-414b-ad44-c94950ae1231)


##Scope

What areas of the site does this effect

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
